### PR TITLE
Upgrade from profile2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,31 +3,65 @@ Profile
 
 Supports configurable user profiles.
 
+This module is the successor to the [Drupal 7 Profile2 module](https://drupal.org/project/profile2).
+
 Installation
 -------------
 
- * Copy the whole profile directory to your modules directory and
-   activate the module.
-
+* Install this module using the official Backdrop CMS instructions at
+  https://backdropcms.org/guide/modules.
 
 Usage
 -----
-   
- * Go to /admin/structure/profiles for managing profile types.
- * By default users may view their profile at /user and edit them at
-   'user/X/edit'.
 
-LICENSE
----------------    
+* Visit the configuration page under Administration > Structure >
+  Profiles (admin/structure/profiles) for managing profile types.
 
-This project is GPL v2 software. See the LICENSE.txt file in this directory 
+* By default users may view their profile at /user and edit them at
+   user/N/edit.
+
+Upgrading from Drupal 7
+-----------------------
+
+This module is the successor to the [Drupal 7 Profile2
+module](https://drupal.org/project/profile2) and will automatically import and
+convert any Profile2 profiles when upgrading from a Drupal 7 installation.
+
+Note that this module does NOT import from the [deprecated Profile
+module](https://www.drupal.org/node/874026) that was provided in Drupal 7 core
+as an upgrade path from Drupal 6 sites that used Profiles. If you have profiles
+from the Drupal 7 Profile module, you should either convert them to Profile2
+profiles in Drupal 7 prior to upgrading to Backdrop, or recreate them in
+Backdrop after you upgrade.
+
+Documentation
+-------------
+
+Additional documentation is located in the [Wiki](https://github.com/backdrop-contrib/me/wiki/Documentation).
+
+Issues
+------
+
+Bugs and feature requests should be reported in the [Issue Queue](https://github.com/backdrop-contrib/me/issues).
+
+License
+---------------
+
+This project is GPL v2 software. See the LICENSE.txt file in this directory
 for complete text.
+
+
+Current Maintainers
+-------------------
+
+* [docwilmot](https://github.com/docwilmot)
 
 Credits:
 ----------
-Ported by docwlmot
 
-Original Drupal maintained module by
- * Wolfgang Ziegler (fago), nuppla@zites.net
- * Joachim Noreiko (joachim), joachim.n+backdrop@gmail.com
+* Ported to Backdrop CMS by [docwilmot](https://github.com/docwilmot).
+
+* Original Drupal maintained module by
+    * [Wolfgang Ziegler (fago)](https://www.drupal.org/u/fago), nuppla@zites.net
+    * [Joachim Noreiko (joachim)](https://www.drupal.org/u/joachim), joachim.n+backdrop@gmail.com
 

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ Backdrop after you upgrade.
 Documentation
 -------------
 
-Additional documentation is located in the [Wiki](https://github.com/backdrop-contrib/me/wiki/Documentation).
+Additional documentation is located in the [Wiki](https://github.com/backdrop-contrib/profile/wiki/Documentation).
 
 Issues
 ------
 
-Bugs and feature requests should be reported in the [Issue Queue](https://github.com/backdrop-contrib/me/issues).
+Bugs and feature requests should be reported in the [Issue Queue](https://github.com/backdrop-contrib/profile/issues).
 
 License
 ---------------
@@ -54,7 +54,7 @@ for complete text.
 Current Maintainers
 -------------------
 
-* [docwilmot](https://github.com/docwilmot)
+* [Robert J. Lang](https://github.com/bugfolder)
 
 Credits:
 ----------

--- a/profile.install
+++ b/profile.install
@@ -94,34 +94,27 @@ function profile_uninstall() {
  *
  * This is here to deal with an update numbering problem in early versions of
  * this module (updates started numbering at 10000, not 1000). If the wrong
- * number is detected in the system table, we flag it on the status page and
- * then fix it so that updates will proceed properly going forward.
+ * number is detected for the last update version, we fix it so that updates
+ * proceed properly going forward.
  */
 function profile_requirements($phase) {
-  if ($phase = 'runtime') {
-    $schema_version = db_query("
-      SELECT schema_version
-      FROM {system}
-      WHERE name = 'profile'
-      ")
-      ->fetchField();
-    if ($schema_version == 10000) {
-      db_query("
-        UPDATE {system}
-        SET schema_version = 1000
-        WHERE name = 'profile'
-        ");
-      return array(
-        'profile' => array(
-          'title' => t('Profile update numbering'),
-          'description' => t('A problem was detected with the update numbering for the Profile module. The problem has been fixed. Please re-run !link.',
-            array('!link' => l('update.php', '/update.php'))),
-          'severity' => REQUIREMENT_ERROR,
-        ),
-      );
-    }
+  if (backdrop_get_installed_schema_version('profile') == 10000) {
+    backdrop_set_installed_schema_version('profile', 1000);
   }
-  return array();
+}
+
+
+/**
+ * Implements hook_update_dependencies().
+ *
+ * Make sure field module has already created the config files before running
+ * update 1001.
+ * @see field_update_1001().
+ */
+function profile_update_dependencies() {
+  $dependencies['profile'][1001] = array(
+      'field' => 1001,
+    );
 }
 
 
@@ -130,20 +123,6 @@ function profile_requirements($phase) {
  */
 function profile_update_1000() {
   config_set('profile.settings', 'profile_display', 'fieldsets');
-}
-
-
-/**
- * Implements hook_update_dependencies().
- *
- * Make sure field module has already created the config files before running
- * the next update.
- * @see field_update_1001().
- */
-function profile_update_dependencies() {
-  $dependencies['profile'][1001] = array(
-      'field' => 1001,
-    );
 }
 
 

--- a/profile.install
+++ b/profile.install
@@ -165,7 +165,7 @@ function profile_update_1001() {
       'weight' => $type['weight'],
       'status' => $type['status'],
       'module' => $type['module'],
-      'storage' => PROFILE_STORAGE_NORMAL,
+      'storage' => 1,
     );
     $config->setData($config_data);
     $config->save();

--- a/profile.install
+++ b/profile.install
@@ -11,6 +11,7 @@
 function profile_install() {
 }
 
+
 /**
  * Implements hook_schema().
  */
@@ -74,8 +75,9 @@ function profile_schema() {
   return $schema;
 }
 
+
 /**
- * Implements hook_uninstall()
+ * Implements hook_uninstall().
  */
 function profile_uninstall() {
   $config_names = config_get_names_with_prefix('profile');
@@ -86,9 +88,168 @@ function profile_uninstall() {
   }
 }
 
+
 /**
- * Implements hook_update_N()
+ * Implements hook_requirements().
+ *
+ * This is here to deal with an update numbering problem in early versions of
+ * this module (updates started numbering at 10000, not 1000). If the wrong
+ * number is detected in the system table, we flag it on the status page and
+ * then fix it so that updates will proceed properly going forward.
  */
-function profile_update_10000() {
+function profile_requirements($phase) {
+  if ($phase = 'runtime') {
+    $schema_version = db_query("
+      SELECT schema_version
+      FROM {system}
+      WHERE name = 'profile'
+      ")
+      ->fetchField();
+    if ($schema_version == 10000) {
+      db_query("
+        UPDATE {system}
+        SET schema_version = 1000
+        WHERE name = 'profile'
+        ");
+      return array(
+        'profile' => array(
+          'title' => t('Profile update numbering'),
+          'description' => t('A problem was detected with the update numbering for the Profile module. The problem has been fixed. Please re-run !link.',
+            array('!link' => l('update.php', '/update.php'))),
+          'severity' => REQUIREMENT_ERROR,
+        ),
+      );
+    }
+  }
+  return array();
+}
+
+
+/**
+ * Initialize the profile settings to use fieldsets.
+ */
+function profile_update_1000() {
   config_set('profile.settings', 'profile_display', 'fieldsets');
+}
+
+
+/**
+ * Implements hook_update_dependencies().
+ *
+ * Make sure field module has already created the config files before running
+ * the next update.
+ * @see field_update_1001().
+ */
+function profile_update_dependencies() {
+  $dependencies['profile'][1001] = array(
+      'field' => 1001,
+    );
+}
+
+
+/**
+ * Migrate any existing Profile2 profiles into this module.
+ */
+function profile_update_1001() {
+  if (!db_table_exists('profile_type')) {
+    return;
+  }
+
+  // Get Profile2 types from the table left behind in the db.
+    $profile2_types = db_query('
+    SELECT *
+    FROM {profile_type}
+    ')
+    ->fetchAllAssoc('id', PDO::FETCH_ASSOC);
+
+  // Create profile.type config files for each type.
+  foreach ($profile2_types as &$type) {
+    $type['data'] = unserialize($type['data']);
+    if (isset($type['data']['roles'])) {
+      // Authenticated role changes its key in Backdrop.
+      if (isset($type['data']['roles']['2'])) {
+        unset($type['data']['roles']['2']);
+        $type['data']['roles'][BACKDROP_AUTHENTICATED_ROLE] =
+          BACKDROP_AUTHENTICATED_ROLE;
+      }
+    }
+    else {
+      $type['data']['roles'] = array();
+    }
+    $config = config('profile.type.' . $type['type']);
+    $config_data = array(
+      'userview' => TRUE,
+      'type' => $type['type'],
+      'label' => $type['label'],
+      'registration' => $type['data']['registration'],
+      'roles' => $type['data']['roles'],
+      'weight' => $type['weight'],
+      'status' => $type['status'],
+      'module' => $type['module'],
+      'storage' => PROFILE_STORAGE_NORMAL,
+    );
+    $config->setData($config_data);
+    $config->save();
+  }
+
+  // Drop the profile_type db table, no longer needed.
+  db_drop_table('profile_type');
+
+  // Backdrop's standard upgrade process converted the Profile2 bundles and
+  // their fields to the new config style, but it left their entity_type as
+  // 'profile2', whereas this module uses the entity_type of 'profile'. So we
+  // need to further convert config files and db tables.
+
+  // Get Profile2 bundles from config and convert to entity_type profile.
+  $config_names = config_get_names_with_prefix('field.bundle.profile2.');
+  foreach ($config_names as $config_file) {
+    $config = config($config_file);
+    $config->setName(str_replace('profile2', 'profile', $config->getName()));
+    $config->set('entity_type', 'profile');
+    $config->save();
+
+    // Remove the bundle data from the variables table.
+    $bundle = $config->get('bundle');
+    update_variable_del('field_bundle_settings__' . $bundle);
+
+    // Remove the old bundle config file that contains 'profile2'.
+    $old_config = config($config_file);
+    $old_config->delete();
+  }
+
+  // Get Profile2 field instances from config and convert to entity_type profile.
+  $config_names = config_get_names_with_prefix('field.instance.profile2.');
+  foreach ($config_names as $config_file) {
+    $config = config($config_file);
+    $config->setName(str_replace('profile2', 'profile', $config->getName()));
+    $config->set('entity_type', 'profile');
+    $config->save();
+
+    // The field tables exist (and have data), but their entity_type is left as
+    // profile2 after Backdrop does its upgrade, so we need to change that
+    // column for the data and revision tables.
+    $field_name = $config->get('field_name');
+    db_update('field_data_' . $field_name)
+      ->fields(array(
+        'entity_type' => 'profile',
+      ))
+      ->condition('entity_type', 'profile2')
+      ->execute();
+    db_update('field_revision_' . $field_name)
+      ->fields(array(
+        'entity_type' => 'profile',
+      ))
+      ->condition('entity_type', 'profile2')
+      ->execute();
+
+    // Remove the old field instance config file that contains 'profile2'.
+    $old_config = config($config_file);
+    $old_config->delete();
+  }
+
+  // Remove the residue of the D7 Profile2 module.
+  db_query("
+    DELETE FROM {system}
+    WHERE name = 'profile2'
+    AND type = 'module'");
 }

--- a/profile.install
+++ b/profile.install
@@ -98,9 +98,12 @@ function profile_uninstall() {
  * proceed properly going forward.
  */
 function profile_requirements($phase) {
-  if (backdrop_get_installed_schema_version('profile') == 10000) {
-    backdrop_set_installed_schema_version('profile', 1000);
+  if ($phase == 'update' || $phase == 'runtime') {
+    if (backdrop_get_installed_schema_version('profile') == 10000) {
+      backdrop_set_installed_schema_version('profile', 1000);
+    }
   }
+  return array();
 }
 
 
@@ -109,6 +112,7 @@ function profile_requirements($phase) {
  *
  * Make sure field module has already created the config files before running
  * update 1001.
+ *
  * @see field_update_1001().
  */
 function profile_update_dependencies() {


### PR DESCRIPTION
This PR responds to this issue: https://github.com/backdrop-contrib/profile/issues/5

It adds a hook_update_N() implementation that migrates any existing Profile2 profiles into this module and cleans up the db and config directory.

It also adds some discussion of the migration to the module README file.

And it addresses an issue with the update numbering. The original first update was numbered 10000, rather than 1000. This change corrects the hook_update_N numbering and fixes the numbering in the system table. Existing installations will still work, with the fix applied as part of the current upgrade process.