### PR TITLE
Issue #44: Initialize array in ProfileBlock::getChildren().

### DIFF
--- a/profile.block.inc
+++ b/profile.block.inc
@@ -53,6 +53,7 @@ class ProfileBlock extends Block {
    * {@inheritdoc}
    */
   function getChildren() {
+    $blocks = [];
     foreach (profile_get_types() as $type => $profile_type) {
       $blocks[$type] = array(
         'info' => t('Profile !label block', array('!label' => $profile_type->label)),


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/profile/issues/44.